### PR TITLE
Remove run attempt from test tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 env:
-  RELEASE_TAG: 0.0.0-fake+run_${{ github.run_id }}_${{ github.run_attempt }}
+  RELEASE_TAG: 0.0.0-fake+run_${{ github.run_id }}
 
 jobs:
   check-dist-updated:


### PR DESCRIPTION
Having `run_attempt` in the release tag means that retrying a failed/timed-out job will never fail (as the attempt no is incrememented)